### PR TITLE
fix(ci): attach built assets correctly to GitHub releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -765,6 +765,27 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -R artifacts
 
+      - name: Collect release assets
+        run: |
+          set -euo pipefail
+          mkdir -p release-assets
+
+          cp artifacts/android-apk/oxplayer-android-arm64-v8a.tar.gz release-assets/
+          cp artifacts/android-apk/oxplayer-android-armeabi-v7a.tar.gz release-assets/
+          cp artifacts/android-apk/oxplayer-android-x86_64.tar.gz release-assets/
+          cp artifacts/android-apk/build/app/outputs/flutter-apk/app-arm64-v8a-release.apk release-assets/
+          cp artifacts/android-apk/build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk release-assets/
+          cp artifacts/android-apk/build/app/outputs/flutter-apk/app-x86_64-release.apk release-assets/
+          cp artifacts/android-apk/build/app/outputs/bundle/release/app-release.aab release-assets/
+
+          cp artifacts/ios-ipa/oxplayer-ios.ipa release-assets/
+          cp artifacts/windows-x64-portable/oxplayer-windows-x64-portable.7z release-assets/
+          cp artifacts/windows-arm64-portable/oxplayer-windows-arm64-portable.7z release-assets/
+          cp artifacts/windows-installer/oxplayer-windows-installer.exe release-assets/
+
+      - name: Show collected release assets
+        run: ls -la release-assets
+
       - name: Read version from pubspec.yaml
         id: version
         run: |
@@ -852,17 +873,17 @@ jobs:
           tag_name: ${{ steps.version.outputs.release_tag }}
           name: OXPlayer ${{ steps.version.outputs.version }} (build ${{ steps.version.outputs.build_number }})
           files: |
-            artifacts/android-apk/oxplayer-android-arm64-v8a.tar.gz
-            artifacts/android-apk/oxplayer-android-armeabi-v7a.tar.gz
-            artifacts/android-apk/oxplayer-android-x86_64.tar.gz
-            artifacts/android-apk/app-arm64-v8a-release.apk
-            artifacts/android-apk/app-armeabi-v7a-release.apk
-            artifacts/android-apk/app-x86_64-release.apk
-            artifacts/android-apk/app-release.aab
-            artifacts/ios-ipa/oxplayer-ios.ipa
-            artifacts/windows-x64-portable/oxplayer-windows-x64-portable.7z
-            artifacts/windows-arm64-portable/oxplayer-windows-arm64-portable.7z
-            artifacts/windows-installer/oxplayer-windows-installer.exe
+            release-assets/oxplayer-android-arm64-v8a.tar.gz
+            release-assets/oxplayer-android-armeabi-v7a.tar.gz
+            release-assets/oxplayer-android-x86_64.tar.gz
+            release-assets/app-arm64-v8a-release.apk
+            release-assets/app-armeabi-v7a-release.apk
+            release-assets/app-x86_64-release.apk
+            release-assets/app-release.aab
+            release-assets/oxplayer-ios.ipa
+            release-assets/oxplayer-windows-x64-portable.7z
+            release-assets/oxplayer-windows-arm64-portable.7z
+            release-assets/oxplayer-windows-installer.exe
             appcast.xml
           draft: true
           prerelease: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -885,6 +885,7 @@ jobs:
             release-assets/oxplayer-windows-arm64-portable.7z
             release-assets/oxplayer-windows-installer.exe
             appcast.xml
+          fail_on_unmatched_files: true
           draft: true
           prerelease: false
           generate_release_notes: true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix release asset publishing by collecting build outputs into a single `release-assets` directory before release upload
- correct Android APK/AAB source paths after `download-artifact` (they are nested under `build/...`)
- upload release files from `release-assets/*` so path/layout differences don’t break releases
- enable `fail_on_unmatched_files: true` in `softprops/action-gh-release` to fail fast when any expected asset is missing

## Root cause
`actions/download-artifact` preserves the uploaded relative paths. Android artifacts were uploaded from nested paths like:
- `build/app/outputs/flutter-apk/app-*-release.apk`
- `build/app/outputs/bundle/release/app-release.aab`

But the release step expected flattened paths under `artifacts/android-apk/*.apk` and `artifacts/android-apk/app-release.aab`, so those assets were not matched/uploaded.

## Validation
- verified workflow paths in `.github/workflows/build.yml`
- ensured all expected release files are copied into `release-assets/` before `Create Release`
- added an explicit listing step (`ls -la release-assets`) for easier debugging in logs

## Impact
Release page will now include APK/EXE and other files consistently, and workflows will fail clearly if any asset is missing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95914e0d-1577-4895-b7d6-2b4f024a551e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95914e0d-1577-4895-b7d6-2b4f024a551e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

