### PR TITLE
fix(ci): publish release immediately after successful build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -886,7 +886,7 @@ jobs:
             release-assets/oxplayer-windows-installer.exe
             appcast.xml
           fail_on_unmatched_files: true
-          draft: true
+          draft: false
           prerelease: false
           generate_release_notes: true
         env:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- publish releases directly by switching `softprops/action-gh-release` from `draft: true` to `draft: false`
- keep previous asset-path fixes intact (`release-assets` collection + strict unmatched-file checks)

## Why this change
Builds were green and release creation succeeded, but releases were being created as **Draft**. Draft releases are easy to miss in the normal published Releases list, which looked like no new release was created.

## Validation
- inspected latest successful run logs for `create-release`
- confirmed assets were uploaded successfully
- confirmed workflow setting had `draft: true`
- changed to `draft: false` so future runs publish the release immediately

## Result
After next successful `Build` workflow run on `main`, a new **published** release should appear with APK/EXE and other assets visible right away.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95914e0d-1577-4895-b7d6-2b4f024a551e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95914e0d-1577-4895-b7d6-2b4f024a551e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

