### PR TITLE
Enable auth debug modal in production and expand Telegram auth diagnostics

### DIFF
--- a/lib/infrastructure/data_repository.dart
+++ b/lib/infrastructure/data_repository.dart
@@ -499,6 +499,10 @@ class DataRepository {
     }
 
     authDebugInfo('Requesting OXPlayer bootstrap session...');
+    debugLogInfo(
+      'Bootstrap request target: ${_formatApiUrl('/me/bootstrap')}',
+      type: LogType.backend,
+    );
     final dio = Dio(
       BaseOptions(
         baseUrl: _config.apiBaseUrl,
@@ -510,11 +514,28 @@ class DataRepository {
     try {
       response = await dio.get<Map<String, dynamic>>('/me/bootstrap');
     } on DioException catch (error) {
+      final statusCode = error.response?.statusCode;
+      final requestUrl = error.requestOptions.uri.toString();
+      final responsePreview = _safeResponsePreview(error.response?.data);
       if (error.response?.statusCode == 401) {
         authDebugError('OXPlayer bootstrap rejected the saved access token.');
+        debugLogError(
+          'Bootstrap rejected (401) [url=$requestUrl]',
+          type: LogType.backend,
+        );
         throw const OxBootstrapUnauthorized();
       }
       authDebugError('OXPlayer bootstrap request failed: $error');
+      debugLogError(
+        'Bootstrap failed [status=${statusCode ?? 'n/a'}] [type=${error.type.name}] [url=$requestUrl]',
+        type: LogType.backend,
+      );
+      if (responsePreview.isNotEmpty) {
+        debugLogError(
+          'Bootstrap error response: $responsePreview',
+          type: LogType.backend,
+        );
+      }
       rethrow;
     }
 
@@ -1815,13 +1836,45 @@ class DataRepository {
     final identity = await _resolveDeviceIdentity();
     final dio = Dio(BaseOptions(baseUrl: _config.apiBaseUrl));
     authDebugInfo('Sending Telegram initData to OXPlayer API...', completeStatus: AuthDebugStatusKey.backendRequestSent);
-    final response = await dio.post<Map<String, dynamic>>(
-      '/auth/telegram',
-      data: <String, dynamic>{
-        'initData': initData,
-        'deviceId': identity.deviceId,
-        if (identity.deviceName != null) 'deviceName': identity.deviceName,
-      },
+    debugLogInfo(
+      'Telegram auth request target: ${_formatApiUrl('/auth/telegram')}',
+      type: LogType.backend,
+    );
+    debugLogInfo(
+      'Telegram auth payload meta: initDataLength=${initData.length}, deviceId=${identity.deviceId}, deviceName=${identity.deviceName ?? '-'}',
+      type: LogType.backend,
+    );
+
+    Response<Map<String, dynamic>> response;
+    try {
+      response = await dio.post<Map<String, dynamic>>(
+        '/auth/telegram',
+        data: <String, dynamic>{
+          'initData': initData,
+          'deviceId': identity.deviceId,
+          if (identity.deviceName != null) 'deviceName': identity.deviceName,
+        },
+      );
+    } on DioException catch (error) {
+      final statusCode = error.response?.statusCode;
+      final requestUrl = error.requestOptions.uri.toString();
+      final responsePreview = _safeResponsePreview(error.response?.data);
+      authDebugError('Telegram backend authentication failed: $error');
+      debugLogError(
+        'Telegram auth failed [status=${statusCode ?? 'n/a'}] [type=${error.type.name}] [url=$requestUrl]',
+        type: LogType.backend,
+      );
+      if (responsePreview.isNotEmpty) {
+        debugLogError(
+          'Telegram auth error response: $responsePreview',
+          type: LogType.backend,
+        );
+      }
+      rethrow;
+    }
+    debugLogSuccess(
+      'Telegram auth response status=${response.statusCode ?? 200}',
+      type: LogType.backend,
     );
 
     final accessToken = response.data?['accessToken']?.toString() ?? '';
@@ -1938,6 +1991,10 @@ class DataRepository {
         'Cannot get WebApp URL. Configure OXPLAYER_TELEGRAM_WEBAPP_SHORT_NAME or OXPLAYER_TELEGRAM_WEBAPP_URL in assets/env/default.env.',
       );
     }
+    debugLogInfo(
+      'Telegram WebApp URL resolved: ${_safeUriForLog(webAppUrl)}',
+      type: LogType.auth,
+    );
 
     final initData = _extractTgWebAppData(webAppUrl);
     if (initData == null || initData.isEmpty) {
@@ -1982,6 +2039,33 @@ class DataRepository {
       return _decodeComponentSafe(rawValue);
     }
     return null;
+  }
+
+  String _formatApiUrl(String path) {
+    final baseUrl = _config.apiBaseUrl.trim();
+    if (baseUrl.isEmpty) return path;
+    final parsed = Uri.tryParse(baseUrl);
+    if (parsed == null) {
+      return '$baseUrl$path';
+    }
+    return parsed.resolve(path).toString();
+  }
+
+  String _safeUriForLog(String rawUrl) {
+    final parsed = Uri.tryParse(rawUrl);
+    if (parsed == null) return 'invalid-url';
+    final host = parsed.host.isEmpty ? '(no-host)' : parsed.host;
+    final path = parsed.path.isEmpty ? '/' : parsed.path;
+    return '${parsed.scheme}://$host$path';
+  }
+
+  String _safeResponsePreview(Object? value) {
+    if (value == null) return '';
+    final text = value.toString().replaceAll('\n', ' ').trim();
+    if (text.isEmpty) return '';
+    const maxLength = 280;
+    if (text.length <= maxLength) return text;
+    return '${text.substring(0, maxLength)}...';
   }
 
   String _decodeComponentSafe(String input) {

--- a/lib/services/auth_debug_service.dart
+++ b/lib/services/auth_debug_service.dart
@@ -1,9 +1,6 @@
 import 'dart:collection';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
-
-import 'settings_service.dart';
 
 enum AuthDebugLevel { info, success, error }
 
@@ -120,7 +117,7 @@ class AuthDebugService extends ChangeNotifier {
     ),
   };
 
-  bool get isEnabled => kDebugMode || (SettingsService.instanceOrNull?.getEnableDebugLogging() ?? false);
+  bool get isEnabled => true;
 
   List<AuthDebugEntry> get entries => _entries.toList().reversed.toList(growable: false);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- always enable `AuthDebugFab`/auth debug modal regardless of build mode so production users can open it immediately
- add detailed backend diagnostics around Telegram login and bootstrap calls
- log request targets, HTTP status/error type, and a short server response preview for failures
- log sanitized WebApp URL host/path to help detect wrong Telegram WebApp wiring without leaking query secrets

## Why
Telegram login currently fails with 404 in production, and the existing debug UI/logging was gated by debug settings. These changes ensure we can capture actionable runtime context directly from affected devices.

## Key diagnostics now visible in modal
- exact resolved backend target URL for `/auth/telegram` and `/me/bootstrap`
- request metadata (initData length, deviceId/deviceName)
- Dio failure details: status code, error type, request URL
- short error response preview body (trimmed)

## Notes
- response preview is capped to a short length to avoid dumping large payloads
- WebApp URL logging is sanitized to scheme/host/path only (no query/fragment)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63f7eb0c-ac18-4f7b-9e35-da771072f3a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63f7eb0c-ac18-4f7b-9e35-da771072f3a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

