### PR TITLE
Enable auth debug modal in production and expand Telegram auth diagnostics

### DIFF
--- a/lib/services/auth_debug_service.dart
+++ b/lib/services/auth_debug_service.dart
@@ -1,5 +1,6 @@
 import 'dart:collection';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
 
 enum AuthDebugLevel { info, success, error }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- always enable `AuthDebugFab`/auth debug modal regardless of build mode so production users can open it immediately
- add detailed backend diagnostics around Telegram login and bootstrap calls
- log request targets, HTTP status/error type, and a short server response preview for failures
- log sanitized WebApp URL host/path to help detect wrong Telegram WebApp wiring without leaking query secrets
- restore missing `flutter/foundation.dart` import in `auth_debug_service.dart` to fix analyzer errors in CI

## Why
Telegram login currently fails with 404 in production, and the existing debug UI/logging was gated by debug settings. These changes ensure we can capture actionable runtime context directly from affected devices.

## Key diagnostics now visible in modal
- exact resolved backend target URL for `/auth/telegram` and `/me/bootstrap`
- request metadata (initData length, deviceId/deviceName)
- Dio failure details: status code, error type, request URL
- short error response preview body (trimmed)

## Notes
- response preview is capped to a short length to avoid dumping large payloads
- WebApp URL logging is sanitized to scheme/host/path only (no query/fragment)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63f7eb0c-ac18-4f7b-9e35-da771072f3a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63f7eb0c-ac18-4f7b-9e35-da771072f3a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

