### PR TITLE
Use session env defines for auth config and keep production debug diagnostics

### DIFF
--- a/lib/infrastructure/config/app_config.dart
+++ b/lib/infrastructure/config/app_config.dart
@@ -20,11 +20,9 @@ class AppConfig {
   final String subdlApiKey;
 
   static Future<AppConfig> load() async {
-    if (!dotenv.isInitialized) {
-      await dotenv.load(fileName: 'assets/env/default.env');
-    }
+    await _ensureLoaded();
 
-    String value(String key) => dotenv.env[key]?.trim() ?? '';
+    String value(String key) => _value(key);
     String valueOrLegacy(String key, String legacyKey) {
       final primary = value(key);
       if (primary.isNotEmpty) return primary;
@@ -53,4 +51,30 @@ class AppConfig {
   bool get hasApiConfig =>
       apiBaseUrl.isNotEmpty &&
       (telegramWebAppShortName.isNotEmpty || telegramWebAppUrl.isNotEmpty);
+
+  static Future<void> _ensureLoaded() async {
+    if (dotenv.isInitialized) return;
+    await dotenv.load(fileName: 'assets/env/default.env');
+  }
+
+  static const Map<String, String> _dartDefineEnvByKey = <String, String>{
+    'TELEGRAM_API_ID': String.fromEnvironment('TELEGRAM_API_ID'),
+    'TELEGRAM_API_HASH': String.fromEnvironment('TELEGRAM_API_HASH'),
+    'BOT_USERNAME': String.fromEnvironment('BOT_USERNAME'),
+    'OXPLAYER_API_BASE_URL': String.fromEnvironment('OXPLAYER_API_BASE_URL'),
+    'TV_APP_API_BASE_URL': String.fromEnvironment('TV_APP_API_BASE_URL'),
+    'OXPLAYER_TELEGRAM_WEBAPP_SHORT_NAME': String.fromEnvironment('OXPLAYER_TELEGRAM_WEBAPP_SHORT_NAME'),
+    'TV_APP_WEBAPP_SHORT_NAME': String.fromEnvironment('TV_APP_WEBAPP_SHORT_NAME'),
+    'OXPLAYER_TELEGRAM_WEBAPP_URL': String.fromEnvironment('OXPLAYER_TELEGRAM_WEBAPP_URL'),
+    'TV_APP_WEBAPP_URL': String.fromEnvironment('TV_APP_WEBAPP_URL'),
+    'SUBDL_API_KEY': String.fromEnvironment('SUBDL_API_KEY'),
+  };
+
+  static String _value(String key) {
+    final fromDefine = _dartDefineEnvByKey[key]?.trim() ?? '';
+    if (fromDefine.isNotEmpty) {
+      return fromDefine;
+    }
+    return dotenv.env[key]?.trim() ?? '';
+  }
 }

--- a/lib/infrastructure/data_repository.dart
+++ b/lib/infrastructure/data_repository.dart
@@ -447,12 +447,14 @@ class DataRepository {
     final apiId = int.tryParse(_config.telegramApiId) ?? 0;
     if (!_config.hasTelegramKeys || apiId <= 0) {
       authDebugError('Telegram API keys are missing in env configuration.');
-      throw StateError('Set TELEGRAM_API_ID and TELEGRAM_API_HASH in assets/env/default.env');
+      throw StateError(
+        'Set TELEGRAM_API_ID and TELEGRAM_API_HASH via --dart-define/--dart-define-from-file or assets/env/default.env',
+      );
     }
     if (!_config.hasApiConfig) {
       authDebugError('OXPlayer API configuration is missing in env configuration.');
       throw StateError(
-        'Set OXPLAYER_API_BASE_URL and OXPLAYER_TELEGRAM_WEBAPP_SHORT_NAME or OXPLAYER_TELEGRAM_WEBAPP_URL in assets/env/default.env',
+        'Set OXPLAYER_API_BASE_URL and OXPLAYER_TELEGRAM_WEBAPP_SHORT_NAME or OXPLAYER_TELEGRAM_WEBAPP_URL via --dart-define/--dart-define-from-file or assets/env/default.env',
       );
     }
 
@@ -1988,7 +1990,7 @@ class DataRepository {
         );
       }
       throw StateError(
-        'Cannot get WebApp URL. Configure OXPLAYER_TELEGRAM_WEBAPP_SHORT_NAME or OXPLAYER_TELEGRAM_WEBAPP_URL in assets/env/default.env.',
+        'Cannot get WebApp URL. Configure OXPLAYER_TELEGRAM_WEBAPP_SHORT_NAME or OXPLAYER_TELEGRAM_WEBAPP_URL via --dart-define/--dart-define-from-file or assets/env/default.env.',
       );
     }
     debugLogInfo(

--- a/lib/infrastructure/telegram/tdlib_controller.dart
+++ b/lib/infrastructure/telegram/tdlib_controller.dart
@@ -123,7 +123,9 @@ class TelegramTdlibFacade implements TdlibFacade {
     required String sessionString,
   }) async {
     if (apiId <= 0 || apiHash.isEmpty) {
-      throw StateError('Set TELEGRAM_API_ID and TELEGRAM_API_HASH in assets/env/default.env');
+      throw StateError(
+        'Set TELEGRAM_API_ID and TELEGRAM_API_HASH via dart-define/dart-define-from-file or assets/env/default.env',
+      );
     }
     final previousGlobal = _globalInitSerial;
     final doneGlobal = Completer<void>();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- keep auth debug modal visible in production for field diagnostics
- expand Telegram/backend auth diagnostics with request target + status + response preview
- fix analyzer regression by restoring missing `flutter/foundation.dart` import
- make auth config prefer runtime env from `--dart-define`/`--dart-define-from-file` over `assets/env/default.env`

## Why
Production builds should consume the session/prod environment passed by CI, not local ngrok defaults from `assets/env/default.env`.

## Config precedence (after change)
1. `String.fromEnvironment(...)` values (supports `--dart-define` and `--dart-define-from-file`)
2. fallback to `assets/env/default.env`

## Additional context
This keeps local development convenient while ensuring production auth points to the intended backend endpoint.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63f7eb0c-ac18-4f7b-9e35-da771072f3a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63f7eb0c-ac18-4f7b-9e35-da771072f3a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

